### PR TITLE
Broken translations when the msgids contain non-ASCII characters

### DIFF
--- a/lib/gettext/runtime/mofile.rb
+++ b/lib/gettext/runtime/mofile.rb
@@ -155,7 +155,7 @@ module GetText
             str = convert_encoding(str, original_strings[i])
           end
         end
-        self[original_strings[i]] = str.freeze
+        self[convert_encoding(original_strings[i], original_strings[i])] = str.freeze
       end
       self
     end


### PR DESCRIPTION
I'm currently working on a project where we're using German as the source language. The problem is that when there are non-ASCII characters in the msgids then the translations can't be found because the keys aren't properly encoded when loading the *.mo file. It's probably just an oversight as the msgstrs are properly encoded.

I wasn't able to make the tests pass before adding this patch so I'm not sure how useful it is. However, I thought it would be better to mention it anyway.
