### PR TITLE
Fix for rmsgmerge (typo)

### DIFF
--- a/lib/gettext/tools/rmsgmerge.rb
+++ b/lib/gettext/tools/rmsgmerge.rb
@@ -452,7 +452,7 @@ module GetText
 
       parser = PoParser.new
       defpo = parser.parse_file(config.defpo, PoData.new, false)
-      refpot = parser.parse_file(config.refstrrefstr, PoData.new, false)
+      refpot = parser.parse_file(config.refpot, PoData.new, false)
 
       m = Merger.new
       result = m.merge(defpo, refpot)


### PR DESCRIPTION
Hello,

There is a problem in lib/gettext/tools/rmsgmerge.rb, preventing it to run properly.
It looks like a simple typo ("refstrrefstr" should be "refpot").

This was broken over 3 years ago, in https://github.com/ruby-gettext/gettext/commit/e8a53de767ee7381bc34ae693bb4863a530a66b0
So I am wondering why this was not caught until now... Is nobody using rmsgmerge?

Anyway, here is a quick fix.

Cheers,
## 

Yves-Eric
