### PR TITLE
add license information to the gemspec

### DIFF
--- a/gettext.gemspec
+++ b/gettext.gemspec
@@ -37,4 +37,5 @@ So you can use GNU gettext tools for maintaining.
   s.add_development_dependency("test-unit")
   s.add_development_dependency("test-unit-notify")
   s.add_development_dependency("test-unit-rr")
+  s.license = "Ruby"
 end


### PR DESCRIPTION
This way you can get this information from the rubygems.org API
