### PR TITLE
rxgettext - added "--add-comments[=TAG]" command line option

### DIFF
--- a/lib/gettext/tools/parser/erb.rb
+++ b/lib/gettext/tools/parser/erb.rb
@@ -31,7 +31,7 @@ module GetText
 
     MAGIC_COMMENT = /\A#coding:.*\n/
 
-    def parse(file) # :nodoc:
+    def parse(file, options = {}) # :nodoc:
       content = IO.read(file)
       src = ERB.new(content).src
 
@@ -46,7 +46,7 @@ module GetText
       end
 
       erb = src.split(/$/)
-      RubyParser.parse_lines(file, erb)
+      RubyParser.parse_lines(file, erb, options)
     end
 
     def detect_encoding(erb_source)

--- a/lib/gettext/tools/parser/glade.rb
+++ b/lib/gettext/tools/parser/glade.rb
@@ -22,13 +22,13 @@ module GetText
     TARGET1 = /<property.*translatable="yes">(.*)/
     TARGET2 = /(.*)<\/property>/
 
-    def parse(file) # :nodoc:
+    def parse(file, options = {}) # :nodoc:
       lines = IO.readlines(file)
-      parse_lines(file, lines)
+      parse_lines(file, lines, options)
     end
 
     #from ary of lines.
-    def parse_lines(file, lines) # :nodoc:
+    def parse_lines(file, lines, options = {}) # :nodoc:
       targets = []
       cnt = 0
       target = false

--- a/lib/gettext/tools/parser/ruby.rb
+++ b/lib/gettext/tools/parser/ruby.rb
@@ -119,7 +119,7 @@ module GetText
     # (and ignored here).
     # And You don't need to keep the poentries as unique.
 
-    def parse(path)  # :nodoc:
+    def parse(path, options = {})  # :nodoc:
       source = IO.read(path)
 
       if source.respond_to?(:encode)
@@ -128,7 +128,7 @@ module GetText
         source.force_encoding(encoding)
       end
 
-      parse_lines(path, source.each_line.to_a)
+      parse_lines(path, source.each_line.to_a, options)
     end
 
     def detect_encoding(source)
@@ -141,7 +141,7 @@ module GetText
       end
     end
 
-    def parse_lines(path, lines)  # :nodoc:
+    def parse_lines(path, lines, options = {})  # :nodoc:
       po = []
       file = StringIO.new(lines.join + "\n")
       rl = RubyLexX.new
@@ -206,7 +206,11 @@ module GetText
           if last_comment.empty?
             # new comment from programmer to translator?
             comment1 = tk.value.lstrip
-            if comment1 =~ /^TRANSLATORS\:/
+            translators_tag = options[:translators_tag]
+
+            if translators_tag.nil?
+              last_comment = comment1
+            elsif comment1 =~ /^#{translators_tag}/
               last_comment = $'
             end
           else

--- a/lib/gettext/tools/xgettext.rb
+++ b/lib/gettext/tools/xgettext.rb
@@ -77,6 +77,7 @@ module GetText
         @msgid_bugs_address = nil
         @copyright_holder = nil
         @output_encoding = nil
+        @parser_options = {:translators_tag => "TRANSLATORS:"}
       end
 
       # The parser object requires to have target?(path) and
@@ -237,6 +238,10 @@ EOH
         parser.on("--output-encoding=ENCODING",
                   _("set encoding for output")) do |encoding|
           @output_encoding = encoding
+
+        parser.on("-c", "--add-comments[=TAG]",
+                  _("add comments preceding the translated text, include the text following the TAG (all if empty) [default: \"TRANSLATORS:\"]")) do |tag|
+          @parser_options[:translators_tag] = tag
         end
 
         parser.on("-r", "--require=library",
@@ -290,7 +295,7 @@ EOH
         @parsers.each do |parser|
           next unless parser.target?(path)
 
-          extracted_po = parser.parse(path)
+          extracted_po = parser.parse(path, @parser_options)
           extracted_po.each do |po_entry|
             if po_entry.kind_of?(Array)
               po_entry = POEntry.new_from_ary(po_entry)


### PR DESCRIPTION
Added to be compatible with GNU xgettext.

The default value is `TRANSLATORS:` for backward compatibility.
