### PR TITLE
Add missing separator when merging comments

### DIFF
--- a/lib/gettext/tools/po_entry.rb
+++ b/lib/gettext/tools/po_entry.rb
@@ -110,7 +110,8 @@ module GetText
     def add_comment(new_comment)
       if (new_comment and ! new_comment.empty?)
         @extracted_comment ||= ""
-        @extracted_comment += new_comment
+        @extracted_comment << "\n" unless @extracted_comment.empty?
+        @extracted_comment << new_comment
       end
       to_s
     end


### PR DESCRIPTION
The same translatable strings with different comments results in merged comments without any separator.

Input Ruby file:

``` ruby
# TRANSLATORS: this is a button label
_("foo")
# TRANSLATORS: this is help text description
_("foo")
```

Result:

```
#. TRANSLATORS: this is a button labelTRANSLATORS: this is help text description
#: ../test.rb:2 ../test.rb:4
msgid "foo"
```

After applying the fix:

```
#. TRANSLATORS: this is a button label
#. TRANSLATORS: this is help text description
#: ../test.rb:2 ../test.rb:4
msgid "foo"
```
