### PR TITLE
rxgettext - added --gnu-compatibility option

### DIFF
--- a/lib/gettext/tools/parser/erb.rb
+++ b/lib/gettext/tools/parser/erb.rb
@@ -31,7 +31,7 @@ module GetText
 
     MAGIC_COMMENT = /\A#coding:.*\n/
 
-    def parse(file) # :nodoc:
+    def parse(file, options = {}) # :nodoc:
       content = IO.read(file)
       src = ERB.new(content).src
 
@@ -46,7 +46,7 @@ module GetText
       end
 
       erb = src.split(/$/)
-      RubyParser.parse_lines(file, erb)
+      RubyParser.parse_lines(file, erb, options)
     end
 
     def detect_encoding(erb_source)

--- a/lib/gettext/tools/parser/glade.rb
+++ b/lib/gettext/tools/parser/glade.rb
@@ -22,13 +22,13 @@ module GetText
     TARGET1 = /<property.*translatable="yes">(.*)/
     TARGET2 = /(.*)<\/property>/
 
-    def parse(file) # :nodoc:
+    def parse(file, options = {}) # :nodoc:
       lines = IO.readlines(file)
-      parse_lines(file, lines)
+      parse_lines(file, lines, options)
     end
 
     #from ary of lines.
-    def parse_lines(file, lines) # :nodoc:
+    def parse_lines(file, lines, options = {}) # :nodoc:
       targets = []
       cnt = 0
       target = false

--- a/lib/gettext/tools/xgettext.rb
+++ b/lib/gettext/tools/xgettext.rb
@@ -77,6 +77,7 @@ module GetText
         @msgid_bugs_address = nil
         @copyright_holder = nil
         @output_encoding = nil
+        @parser_options = {:translators_tag => "TRANSLATORS:"}
       end
 
       # The parser object requires to have target?(path) and
@@ -244,6 +245,11 @@ EOH
           require out
         end
 
+        parser.on("-g", "--gnu-compatible",
+                  _("Create PO file compatible with GNU gettext")) do
+          @parser_options[:gnu_compatibility] = true
+        end
+
         parser.on("-d", "--debug", _("run in debugging mode")) do
           $DEBUG = true
         end
@@ -290,7 +296,7 @@ EOH
         @parsers.each do |parser|
           next unless parser.target?(path)
 
-          extracted_po = parser.parse(path)
+          extracted_po = parser.parse(path, @parser_options)
           extracted_po.each do |po_entry|
             if po_entry.kind_of?(Array)
               po_entry = POEntry.new_from_ary(po_entry)


### PR DESCRIPTION
to produce a GNU gettext compatible PO file (no double escaped new line charaters, removed Plural-Forms header tag)

Small implementation change: subclass `RubyPOEntry` from `POEntry` to reuse the `format_message` method and to avoid aliasing `initialization` method.
