### PR TITLE
Support Pathnames in $LOAD_PATH

### DIFF
--- a/lib/gettext/locale_path.rb
+++ b/lib/gettext/locale_path.rb
@@ -48,7 +48,7 @@ module GetText
         default_path_rules += DEFAULT_RULES
 
         load_path = $LOAD_PATH.dup
-        load_path.map!{|v| v.match(/(.*?)(\/lib)*?$/); $1}
+        load_path.map!{|v| (v.respond_to?(:to_path) ? v.to_path : v).match(/(.*?)(\/lib)*?$/); $1}
         load_path.each {|path|
           default_path_rules += [
             "#{path}/data/locale/%{lang}/LC_MESSAGES/%{name}.mo",


### PR DESCRIPTION
This allows `$LOAD_PATH` to contain [Pathname](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/pathname/rdoc/Pathname.html) objects in addition to strings. Previously Pathnames would break any attempt to precompile assets because of an undefined `match` method.
