### PR TITLE
task: Fix undefined method `po_file'

### DIFF
--- a/lib/gettext/tools/task.rb
+++ b/lib/gettext/tools/task.rb
@@ -455,7 +455,8 @@ module GetText
                 "rake #{_task.name} LOCALE=${LOCALE}'"
             end
             define_po_file_task(locale)
-            Rake::Task[po_file(locale)].invoke
+            path = create_path(locale)
+            Rake::Task[path.po_file].invoke
           end
 
           update_tasks = []


### PR DESCRIPTION
I encountered a following undefined method error like this:

```log
% bundle exec rake gettext:po:add LOCALE=en
rake aborted!
NoMethodError: undefined method `po_file' for #<GetText::Tools::Task:0x007f4963080b48>
/home/.../vendor/bundle/ruby/2.2.0/gems/gettext-3.1.6/lib/gettext/tools/task.rb:458:in `block (2 levels) in define_po_tasks'
Tasks: TOP => gettext:po:add
(See full trace by running task with --trace)
```