### PR TITLE
Allows 3 character language names

### DIFF
--- a/lib/gettext/tools/task.rb
+++ b/lib/gettext/tools/task.rb
@@ -515,7 +515,7 @@ module GetText
 
         Dir.open(po_base_directory) do |dir|
           dir.each do |entry|
-            next unless /\A[a-z]{2}(?:_[A-Z]{2})?\z/ =~ entry
+            next unless /\A[a-z]{2,3}(?:_[A-Z]{2})?\z/ =~ entry
             next unless File.directory?(File.join(dir.path, entry))
             locales << entry
           end


### PR DESCRIPTION
Hi, this is to allow the standard code for Filipino ('fil' according to ISO639-2). It does not have a two-letter ISO639-1 code thus there's no correct way of using this locale.