### PR TITLE
 Remove character classes with duplicated range

### DIFF
--- a/lib/gettext/tools/msgcat.rb
+++ b/lib/gettext/tools/msgcat.rb
@@ -124,7 +124,7 @@ module GetText
           new_msgstr = ""
           msgstr.each_line do |line|
             case line
-            when /\A([\w\d\-_]+):/
+            when /\A([\w\-]+):/
               name = $1
               next if remove_header_fields.include?(name)
             end


### PR DESCRIPTION
 \w includes \d and _ inside it