### PR TITLE
Apply msgmerge_options to edit PO to PO merge

### DIFF
--- a/lib/gettext/tools/task.rb
+++ b/lib/gettext/tools/task.rb
@@ -370,6 +370,7 @@ module GetText
                          "--sort-by-file",
                          "--no-wrap",
                          "--no-obsolete-entries",
+                         *@msgmerge_options,
                          path.po_file.to_s,
                          path.edit_po_file.to_s)
           end


### PR DESCRIPTION
Allows for msgmerge options such as disabling fuzzy matching to have an
effect on the final PO file.