### PR TITLE
Make languages like zn-Hant and zn-Hans coexist (or bs-Cyrl-BA and bs-Latn-BA)

### DIFF
--- a/lib/gettext/locale_path.rb
+++ b/lib/gettext/locale_path.rb
@@ -95,7 +95,7 @@ module GetText
     # Gets the current path.
     # * lang: a Locale::Tag.
     def current_path(lang)
-      lang_candidates = lang.to_posix.candidates
+      lang_candidates = lang.candidates
 
       lang_candidates.each do |tag|
         path = @locale_paths[tag.to_s]

--- a/lib/gettext/text_domain.rb
+++ b/lib/gettext/text_domain.rb
@@ -122,7 +122,7 @@ module GetText
         ret = nil
       elsif msg.include?("\000")
         # [[msgstr[0], msgstr[1], msgstr[2],...], cond]
-        mo = @mofiles[lang.to_posix.to_s]
+        mo = @mofiles[lang.to_s]
         cond = (mo and mo != :empty) ? mo.plural_as_proc : DEFAULT_PLURAL_CALC
         ret = [msg.split("\000"), cond]
       else
@@ -147,7 +147,6 @@ module GetText
     # Load a mo-file from the file.
     # lang is the subclass of Locale::Tag::Simple.
     def load_mo(lang)
-      lang = lang.to_posix unless lang.kind_of? Locale::Tag::Posix
       lang_key = lang.to_s
 
       mo = @mofiles[lang_key]
@@ -163,7 +162,7 @@ module GetText
       path = @locale_path.current_path(lang)
 
       if path
-        charset = @output_charset || lang.charset || Locale.charset || "UTF-8"
+        charset = @output_charset || lang.to_posix.charset || Locale.charset || "UTF-8"
         charset = normalize_charset(charset)
         @mofiles[lang_key] = MO.open(path, charset)
       else

--- a/test/po/zh_Hant/test1.po
+++ b/test/po/zh_Hant/test1.po
@@ -1,0 +1,23 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2002-01-01 02:24:56+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: ENCODING\n"
+
+#: simple.rb:10
+msgid "language"
+msgstr "traditional Japanese"
+
+#: simple.rb:14
+msgid "one is %d."
+msgstr "TRADITIONAL JAPANESE:ONE IS %d."

--- a/test/test_locale_path.rb
+++ b/test/test_locale_path.rb
@@ -52,18 +52,20 @@ class TestLocalePath < Test::Unit::TestCase
   def test_initialize_with_topdir
     testdir = File.dirname(File.expand_path(__FILE__))
     path = GetText::LocalePath.new("test1", "#{testdir}/locale")
-    assert_equal path.locale_paths, { "ja" => "#{testdir}/locale/ja/LC_MESSAGES/test1.mo",
-                                     "fr" => "#{testdir}/locale/fr/LC_MESSAGES/test1.mo"}
+    assert_equal path.locale_paths, { "ja"      => "#{testdir}/locale/ja/LC_MESSAGES/test1.mo",
+                                      "fr"      => "#{testdir}/locale/fr/LC_MESSAGES/test1.mo",
+                                      "zh_Hant" => "#{testdir}/locale/zh_Hant/LC_MESSAGES/test1.mo"}
     assert_equal path.current_path(Locale::Tag.parse("ja")), "#{testdir}/locale/ja/LC_MESSAGES/test1.mo"
     assert_equal path.current_path(Locale::Tag.parse("ja-JP")), "#{testdir}/locale/ja/LC_MESSAGES/test1.mo"
     assert_equal path.current_path(Locale::Tag.parse("ja_JP.UTF-8")), "#{testdir}/locale/ja/LC_MESSAGES/test1.mo"
     assert_equal path.current_path(Locale::Tag.parse("en")), nil
+    assert_equal path.current_path(Locale::Tag.parse("zh-Hant")), "#{testdir}/locale/zh_Hant/LC_MESSAGES/test1.mo"
   end
 
   def test_supported_locales
     testdir = File.dirname(File.expand_path(__FILE__))
     path = GetText::LocalePath.new("test1", "#{testdir}/locale")
-    assert_equal ["fr", "ja"], path.supported_locales
+    assert_equal ["fr", "ja", "zh_Hant"], path.supported_locales
 
     path = GetText::LocalePath.new("plural", "#{testdir}/locale")
     assert_equal ["cr", "da", "fr", "ir", "ja", "la", "li", "po", "sl"], path.supported_locales


### PR DESCRIPTION
Hi there,

We encountered an issue on Gettext when using very specific languages like "zh-Hant" and "zh-Hans" or "az-Cyrl-AZ" and "az-Latn-AZ" at the same time in a project.

When looking for the right language path (where is the MO file), the code iterates through `lang.to_posix.candidates` and keeps the first matching path. Which is usually the right solution.

See: https://github.com/ruby-gettext/gettext/blob/master/lib/gettext/locale_path.rb#L97

But with "zh-Hant" or "zh-Hans", the issue is that the only returned candidate is "zh" without distinction.

Another example: for "az-Cyrl-AZ" and "az-Latn-AZ", the only candidates are "az_AZ" and "az".

When using only one language, it works (but we need to know how to name the directory and that's not intuitive). But when using both "zh-Hant" and "zh-Hans", it breaks because Gettext is looking into /zh/ directory for both the languages.

It's not right because some of our customers uses zh-Hant *and* zh-Hans at the same time for traditional and simplified Chinese. And it can't work.

We created a simple patch to fix this issue. We iterated through `lang.candidates` (without `to_posix`) which is a shortcut for `lang.to_common.candidates`.

It works because:

```ruby
# before
Locale::Tag.parse('zh-Hant').to_posix.candidates.collect(&:to_s).uniq
> ["zh"]

# after
Locale::Tag.parse('zh-Hant').candidates.collect(&:to_s).uniq
> ["zh_Hant", "zh"]
```

and

```ruby
# before
Locale::Tag.parse('az-Latn-AZ').to_posix.candidates.collect(&:to_s).uniq
> ["az_AZ", "az"]

# after
Locale::Tag.parse('az-Latn-AZ').candidates.collect(&:to_s).uniq
> ["az_Latn_AZ", "az_AZ", "az_Latn", "az"]
```

With this patch, Gettext will support more directory names for languages (and manage more fallbacks).

(we also renamed 2 test files because it always break in case-insensitive filesystems and it certainly is discouraging when testing the project. we hope you'll agree with this small fix too).
