### PR TITLE
Remove the samples directory from the gem

### DIFF
--- a/gettext.gemspec
+++ b/gettext.gemspec
@@ -19,7 +19,7 @@ So you can use GNU gettext tools for maintaining.
   s.rubyforge_project = "gettext"
   s.require_paths = ["lib"]
   Dir.chdir(base_dir) do
-    s.files = Dir.glob("{locale,bin,data,doc/text,lib,po,samples,src,test}/**/*")
+    s.files = Dir.glob("{locale,bin,data,doc/text,lib,po,src,test}/**/*")
     s.files += ["README.md", "Rakefile", "gettext.gemspec"]
     s.files += [".yardopts"]
     s.executables = Dir.chdir("bin") do


### PR DESCRIPTION
We've found that the additional 5MB (compressed!) of data that the `samples` directory adds when installing this gem can be painfully large (particularly when in use on Heroku, where every extra byte slows down deploy time).

You may have this directory included for simpler gem -> linux package conversion (a similar issue [has been discussed on rubygems](https://github.com/rubygems/rubygems/issues/735)) but just in case, here's a PR to slim down your gem.
