### PR TITLE
Get tests passing with frozen-string-literals enabled.

### DIFF
--- a/lib/gettext/mo.rb
+++ b/lib/gettext/mo.rb
@@ -43,8 +43,8 @@ module GetText
       :trans_sysdep_tab_offset
     end
 
-    MAGIC_BIG_ENDIAN    = "\x95\x04\x12\xde".force_encoding("ASCII-8BIT")
-    MAGIC_LITTLE_ENDIAN = "\xde\x12\x04\x95".force_encoding("ASCII-8BIT")
+    MAGIC_BIG_ENDIAN    = "\x95\x04\x12\xde".dup.force_encoding("ASCII-8BIT")
+    MAGIC_LITTLE_ENDIAN = "\xde\x12\x04\x95".dup.force_encoding("ASCII-8BIT")
 
     def self.open(arg = nil, output_charset = nil)
       result = self.new(output_charset)
@@ -325,7 +325,7 @@ module GetText
     end
 
     def generate_original_string(msgid, options)
-      string = ""
+      string = "".dup
 
       msgctxt = options.delete(:msgctxt)
       msgid_plural = options.delete(:msgid_plural)

--- a/lib/gettext/po.rb
+++ b/lib/gettext/po.rb
@@ -194,7 +194,7 @@ module GetText
     # @return [String] Formatted and joined PO entries. It is used for
     #   creating .po files.
     def to_s(options={})
-      po_string = ""
+      po_string = "".dup
 
       header_entry = @entries[[nil, ""]]
       unless header_entry.nil?

--- a/lib/gettext/po_entry.rb
+++ b/lib/gettext/po_entry.rb
@@ -83,7 +83,7 @@ module GetText
     # @return [void]
     def add_comment(new_comment)
       if (new_comment and ! new_comment.empty?)
-        @extracted_comment ||= ""
+        @extracted_comment ||= "".dup
         @extracted_comment << "\n" unless @extracted_comment.empty?
         @extracted_comment << new_comment
       end
@@ -366,7 +366,7 @@ module GetText
       end
 
       def format_comments
-        formatted_comment = ""
+        formatted_comment = "".dup
         if include_translator_comment?
           formatted_comment << format_translator_comment
         end
@@ -395,7 +395,7 @@ module GetText
 
       def format_reference_comment
         max_line_width = @options[:max_line_width]
-        formatted_reference = ""
+        formatted_reference = "".dup
         if not @entry.references.nil? and not @entry.references.empty?
           formatted_reference << REFERENCE_COMMENT_MARK
           line_width = 2
@@ -417,7 +417,7 @@ module GetText
       end
 
       def format_flag_comment
-        formatted_flags = ""
+        formatted_flags = "".dup
         @entry.flags.each do |flag|
           formatted_flags << format_comment(FLAG_MARK, flag)
         end
@@ -431,7 +431,7 @@ module GetText
       def format_comment(mark, comment)
         return "" if comment.nil?
 
-        formatted_comment = ""
+        formatted_comment = "".dup
         comment.each_line do |comment_line|
           if comment_line == "\n"
             formatted_comment << "#{mark}\n"
@@ -446,7 +446,7 @@ module GetText
         mark = "#~"
         return "" if comment.nil?
 
-        formatted_comment = ""
+        formatted_comment = "".dup
         comment.each_line do |comment_line|
           if /\A#[^~]/ =~ comment_line or comment_line.start_with?(mark)
             formatted_comment << "#{comment_line.chomp}\n"
@@ -466,7 +466,7 @@ module GetText
         chunks = wrap_message(message)
         return empty_formatted_message if chunks.empty?
 
-        formatted_message = ""
+        formatted_message = "".dup
         if chunks.size > 1 or chunks.first.end_with?("\n")
           formatted_message << empty_formatted_message
         end

--- a/lib/gettext/tools/msgcat.rb
+++ b/lib/gettext/tools/msgcat.rb
@@ -121,7 +121,7 @@ module GetText
           msgstr = header_entry.msgstr
           return if msgstr.nil?
 
-          new_msgstr = ""
+          new_msgstr = "".dup
           msgstr.each_line do |line|
             case line
             when /\A([\w\-]+):/

--- a/lib/gettext/tools/parser/ruby.rb
+++ b/lib/gettext/tools/parser/ruby.rb
@@ -236,7 +236,7 @@ module GetText
 
       po_entry = nil
       line_no = nil
-      last_comment = ""
+      last_comment = "".dup
       reset_comment = false
       ignore_next_comma = false
       rl.parse do |tk|
@@ -287,7 +287,7 @@ module GetText
 
         case tk
         when RubyToken::TkCOMMENT_WITH_CONTENT
-          last_comment = "" if reset_comment
+          last_comment = "".dup if reset_comment
           if last_comment.empty?
             comment1 = tk.value.lstrip
             if comment_to_be_extracted?(comment1)

--- a/test/test_po.rb
+++ b/test/test_po.rb
@@ -208,7 +208,7 @@ class TestPO < Test::Unit::TestCase
     def setup
       @po = GetText::PO.new
       parser = GetText::POParser.new
-      parser.parse(<<-PO, @po)
+      parser.parse(<<-PO.dup, @po)
 #: hello.rb:2
 msgid "World"
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 
     class TestHeader < self
       def test_no_entry
-        @po[""] = <<-HEADER
+        @po[""] = <<-HEADER.dup
 Project-Id-Version: test 1.0.0
 POT-Creation-Date: 2012-10-31 12:40+0900
 PO-Revision-Date: 2012-11-01 17:46+0900
@@ -312,7 +312,7 @@ Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 Plural-Forms: nplurals=2; plural=(n != 1)
         HEADER
-        @po[""].translator_comment = <<-HEADER_COMMENT
+        @po[""].translator_comment = <<-HEADER_COMMENT.dup
 Japanese translations for test package.
 Copyright (C) 2012 THE PACKAGE'S COPYRIGHT HOLDER
 This file is distributed under the same license as the PACKAGE package.

--- a/test/tools/test_msginit.rb
+++ b/test/tools/test_msginit.rb
@@ -81,7 +81,7 @@ class TestToolsMsgInit < Test::Unit::TestCase
     options = default_po_header_options.merge(options)
     package_name = options[:package_name] || default_package_name
     have_plural_forms = options[:have_plural_forms] || true
-    header = <<EOF
+    header = <<EOF.dup
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.

--- a/test/tools/test_msgmerge.rb
+++ b/test/tools/test_msgmerge.rb
@@ -41,11 +41,11 @@ class TestToolsMsgMerge < Test::Unit::TestCase
 
     class TestUpdate < self
       def test_msgstr
-        pot = <<-POT
+        pot = <<-POT.dup
 msgid "hello"
 msgstr ""
         POT
-        po = <<-PO
+        po = <<-PO.dup
 msgid "hello"
 msgstr "bonjour"
         PO
@@ -67,11 +67,11 @@ msgstr "bonjour"
 
     class TestObosleteEntry < self
       def test_in_po
-        pot = <<-POT
+        pot = <<-POT.dup
 msgid "hello"
 msgstr ""
         POT
-        po = <<-PO
+        po = <<-PO.dup
 msgid "hello"
 msgstr "bonjour"
 


### PR DESCRIPTION
These changes ensure that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards). I would recommend adding the following to your `.travis.yml` file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4). Please note: tests will currently fail when this flag is set unless `test-unit` is also updated (as noted in https://github.com/test-unit/test-unit/pull/149).