### PR TITLE
Fixing sorting of msgids when translations with context are present

### DIFF
--- a/lib/gettext/po.rb
+++ b/lib/gettext/po.rb
@@ -268,7 +268,9 @@ module GetText
     def sort_by_msgid(entries)
       entries.sort_by do |msgid_entry|
         # msgid_entry = [[msgctxt, msgid], POEntry]
-        msgid_entry[0]
+        msgctxt = msgid_entry[0][0] || ""
+        msgid = msgid_entry[0][0]
+        [msgctxt, msgid]
       end
     end
   end

--- a/lib/gettext/po.rb
+++ b/lib/gettext/po.rb
@@ -269,7 +269,7 @@ module GetText
       entries.sort_by do |msgid_entry|
         # msgid_entry = [[msgctxt, msgid], POEntry]
         msgctxt = msgid_entry[0][0] || ""
-        msgid = msgid_entry[0][0]
+        msgid = msgid_entry[0][1]
         [msgctxt, msgid]
       end
     end

--- a/lib/gettext/tools/parser/ruby.rb
+++ b/lib/gettext/tools/parser/ruby.rb
@@ -263,7 +263,17 @@ module GetText
           when RubyToken::TkBITOR
             po_entry = nil
           when RubyToken::TkSTRING, RubyToken::TkDSTRING
-            po_entry.set_current_attribute tk.value if po_entry
+            if po_entry
+              msg_entry = tk.value.split("|")
+              if msg_entry.length > 1 && po_entry.msgid.nil?
+                po_entry.type = :msgctxt
+                po_entry.set_current_attribute msg_entry[0]
+                po_entry.advance_to_next_attribute
+                po_entry.set_current_attribute msg_entry[1]
+              else
+                po_entry.set_current_attribute tk.value
+              end
+            end
           when RubyToken::TkPLUS, RubyToken::TkNL
             #do nothing
           when RubyToken::TkINTEGER


### PR DESCRIPTION
When there are some translations with context and some without, `sort_by` tries to compare string with nil and fails. This fix converts the nils to empty string before comparison.