### PR TITLE
Fix warning: assigned but unused variable - sorted_entries

### DIFF
--- a/lib/gettext/po.rb
+++ b/lib/gettext/po.rb
@@ -222,11 +222,11 @@ module GetText
     def sort(entries)
       case @order
       when :reference, :references # :references is deprecated.
-        sorted_entries = sort_by_reference(entries)
+        sort_by_reference(entries)
       when :msgid
-        sorted_entries = sort_by_msgid(entries)
+        sort_by_msgid(entries)
       else
-        sorted_entries = entries.to_a
+        entries.to_a
       end
     end
 


### PR DESCRIPTION
This PR fixes a ruby level warning.

"sorted_entries" is a descriptive variable name, it is easy to read.
However, even if there is no local variable name, I think it is obvious to return "sorted_entries" here.