### PR TITLE
n_('singular', 'plural', 2) won't return nil anymore if PO contains msgstr[1] ""'

### DIFF
--- a/lib/gettext/text_domain.rb
+++ b/lib/gettext/text_domain.rb
@@ -124,7 +124,7 @@ module GetText
         # [[msgstr[0], msgstr[1], msgstr[2],...], cond]
         mo = @mofiles[lang.to_s]
         cond = (mo and mo != :empty) ? mo.plural_as_proc : DEFAULT_PLURAL_CALC
-        ret = [msg.split("\000"), cond]
+        ret = [msg.split("\000", -1), cond]
       else
         ret = [[msg], DEFAULT_SINGLE_CALC]
       end

--- a/test/po/fr/plural_error.po
+++ b/test/po/fr/plural_error.po
@@ -13,8 +13,15 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=US-ASCII\n"
 "Content-Transfer-Encoding: ENCODING\n"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
 
 #: hello_plural.rb:11
 msgid "first"
 msgid_plural "second"
 msgstr[0] "fr_first"
+
+#: hello_plural.rb:14
+msgid "first_2"
+msgid_plural "second_2"
+msgstr[0] "fr_first_2"
+msgstr[1] ""

--- a/test/test_gettext.rb
+++ b/test/test_gettext.rb
@@ -235,7 +235,10 @@ DDD
     set_locale("fr")
     assert_equal("fr_first", n_("first", "second", 0))
     assert_equal("fr_first", n_("first", "second", 1))
-    assert_equal("fr_first", n_("first", "second", 2))
+    assert_equal("fr_first", n_("first", "second", 2)) # no translation
+    assert_equal("fr_first_2", n_("first_2", "second_2", 0))
+    assert_equal("fr_first_2", n_("first_2", "second_2", 1))
+    assert_equal("", n_("first_2", "second_2", 2))     # empty translation
     set_locale("da") # Invalid Plural-Forms.
     assert_equal("da_first", n_("first", "second", 0))
     assert_equal("da_first", n_("first", "second", 1))


### PR DESCRIPTION
Hello,

We noticed a small bug where `n_("singular", "plural", 2)` returned `nil` when the PO contains something like this:

```
msgid "singular"
msgid_plural "plural"
msgstr[0] "singular translation"
msgstr[1] ""
```

Usually it's not a big deal, but with `n_` we usually do constructions like this: 

```ruby
n_('%{seconds} second', '%{seconds} seconds', 2) % { seconds: 2 }
```

And it raises `undefined method % for nil.`, so it certainly need to be fixed.

I hope it will be merged.
Have a nice day!