### PR TITLE
Fix sorting by msgid when a msgctxt is present

### DIFF
--- a/lib/gettext/po.rb
+++ b/lib/gettext/po.rb
@@ -268,7 +268,7 @@ module GetText
     def sort_by_msgid(entries)
       entries.sort_by do |msgid_entry|
         # msgid_entry = [[msgctxt, msgid], POEntry]
-        msgid_entry[0]
+        msgid_entry[0][1]
       end
     end
   end

--- a/test/tools/test_xgettext.rb
+++ b/test/tools/test_xgettext.rb
@@ -490,6 +490,28 @@ msgstr ""
         POT
       end
 
+      def test_sort_by_msgid_with_mixed_contexts
+        assert_equal(<<-POT, generate_with_mixed_contexts("--sort-by-msgid"))
+#{header}
+#: ../templates/xgettext.rhtml:2
+msgid "123"
+msgstr ""
+
+#: ../templates/xgettext.rhtml:1
+msgid "ABC"
+msgstr ""
+
+#: ../lib/xgettext.rb:2
+msgctxt "zContext"
+msgid "Hello"
+msgstr ""
+
+#: ../lib/xgettext.rb:1
+msgid "World"
+msgstr ""
+        POT
+      end
+
       private
       def generate(*command_line_options)
         File.open(@rhtml_file_path, "w") do |rhtml_file|
@@ -503,6 +525,29 @@ msgstr ""
           rb_file.puts(<<-RUBY)
 _('World')
 _('Hello')
+          RUBY
+        end
+
+        command_line = ["--output", @pot_file_path]
+        command_line += command_line_options
+        command_line += [@rhtml_file_path, @rb_file_path]
+        @xgettext.run(*command_line)
+
+        File.read(@pot_file_path)
+      end
+
+      def generate_with_mixed_contexts(*command_line_options)
+        File.open(@rhtml_file_path, "w") do |rhtml_file|
+          rhtml_file.puts(<<-RHTML)
+<%= _("ABC") %>
+<%= _("123") %>
+          RHTML
+        end
+
+        File.open(@rb_file_path, "w") do |rb_file|
+          rb_file.puts(<<-RUBY)
+_('World')
+p_('zContext','Hello')
           RUBY
         end
 


### PR DESCRIPTION
The sort_by_msgid errors when an entry has a msgctxt present. This seems like an oversight.