### PR TITLE
Find racc executable even in Ruby 2.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,8 @@ end
 
 po_parser_ry_path = "src/po_parser.ry"
 file po_parser_rb_path => po_parser_ry_path do
-  racc = File.join(Gem.bindir, "racc")
+  racc_spec = Gem::Specification.find_by_name("racc")
+  racc = File.join(racc_spec.bin_dir, racc_spec.executable)
   tempfile = Tempfile.new("gettext-po-parser")
   ruby(racc, "-g", po_parser_ry_path, "-o", tempfile.path)
 


### PR DESCRIPTION
Hi,

I found racc executable file is not included in `Gem.bindir` for now, in Ruby 2.7 because now it is shipped with Ruby itself! So, I made it more generic to find racc executable.

I'm interested in issue #64 but at fist we need make Rake tasks work.

Thanks.