### PR TITLE
Add regression-fixture for  #68

### DIFF
--- a/test/fixtures/_/shell_calls_should_not_be_translated.rb
+++ b/test/fixtures/_/shell_calls_should_not_be_translated.rb
@@ -1,0 +1,3 @@
+def shell_calls_should_not_be_translated
+  `i should not be translated`
+end


### PR DESCRIPTION
This fails if you call `bundle exec rake test`, for the Raketask tests. It seems that the content of a shell call: `echo hi` will be passed to the parsers method for tstrings. 

Further information:  #68