### PR TITLE
Define task to build *.edit.po in gettext:po:add task

### DIFF
--- a/lib/gettext/tools/task.rb
+++ b/lib/gettext/tools/task.rb
@@ -381,6 +381,7 @@ module GetText
         return unless @enable_po
 
         path = create_path(locale)
+        define_edit_po_file_task(locale)
         directory path.po_directory.to_s
         dependencies = [
           path.edit_po_file.to_s,

--- a/lib/gettext/tools/task.rb
+++ b/lib/gettext/tools/task.rb
@@ -381,7 +381,6 @@ module GetText
         return unless @enable_po
 
         path = create_path(locale)
-        define_edit_po_file_task(locale)
         directory path.po_directory.to_s
         dependencies = [
           path.edit_po_file.to_s,
@@ -456,6 +455,7 @@ module GetText
                 "'rake #{_task.name}[${LOCALE}]' or " +
                 "rake #{_task.name} LOCALE=${LOCALE}'"
             end
+            define_edit_po_file_task(locale)
             define_po_file_task(locale)
             path = create_path(locale)
             Rake::Task[path.po_file].invoke


### PR DESCRIPTION
Hi,

In some case, `gettext:po:add[locale]` task fails.

When we are at, for example, commit 3434ab3 of this gettext repository, we cannot execute the task with lang argument which doesn't exist for now:

    % bundle exec rake 'test:_:gettext:po:add[zh]' -t
    ** Invoke test:_:gettext:po:add (first_time)
    ** Execute test:_:gettext:po:add
    ** Invoke test/po/zh/_.po (first_time)
    rake aborted!
    Don't know how to build task 'test/po/zh/_.edit.po' (See the list of available tasks with `rake --tasks`)
    Did you mean?  test/po/ja/_.edit.po
    test/po/ja/s_.edit.po
    test/po/zh/_.po
    test/po/ja/ns_.edit.po
    test/po/ja/p_.edit.po
    test/po/ja/np_.edit.po
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task_manager.rb:59:in `[]'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:66:in `lookup_prerequisite'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:62:in `block in prerequisite_tasks'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:62:in `map'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:62:in `prerequisite_tasks'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:241:in `invoke_prerequisites'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:218:in `block in invoke_with_call_chain'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:199:in `synchronize'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:188:in `invoke'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/lib/gettext/tools/task.rb:461:in `block (2 levels) in define_po_tasks'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:279:in `block in execute'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:279:in `each'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:279:in `execute'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:199:in `synchronize'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:188:in `invoke'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:160:in `invoke_task'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:116:in `block (2 levels) in top_level'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:116:in `each'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:116:in `block in top_level'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:125:in `run_with_threads'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:110:in `top_level'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:83:in `block in run'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:186:in `standard_exception_handling'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:80:in `run'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/bin/rake:23:in `load'
    /home/kitaitimakoto/src/github.com/ruby-gettext/gettext/vendor/bundle/ruby/2.7.0/bin/rake:23:in `<top (required)>'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
    /home/kitaitimakoto/.gem/ruby/2.7.0/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
    /home/kitaitimakoto/.gem/ruby/2.7.0/bin/bundle:23:in `load'
    /home/kitaitimakoto/.gem/ruby/2.7.0/bin/bundle:23:in `<main>'
    Tasks: TOP => test/po/zh/_.po

I wrote a patch to fix this problem. Can you consider it?

Thanks.