### PR TITLE
Point to news.md for changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 NB This file is largely obsolete and is preserved for historical interest.  
-For up to date summaries of recent releases' changes, see the file doc/text/news.md
+For up to date summaries of recent releases' changes, see the file:
+
+doc/text/news.md
 
 ==========================================================================
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+NB This file is largely obsolete and is preserved for historical interest.  
+For up to date summaries of recent releases' changes, see the file doc/text/news.md
+
+==========================================================================
+
 = Ruby-GetText-Package-2.2.1 (2012-05-20)
  * Supported non ASCII string in msgid. [GitHub#1]
    [Patch by Urban Hafner]


### PR DESCRIPTION
depfu automatically generates links to gems' ChangeLog files when it detects a new release, but this file is not current.
Add a pointer to the file containing the information needed.