### PR TITLE
Locale fallback if missing translation (ex: `en_US` => `en`)

### DIFF
--- a/lib/gettext/text_domain_manager.rb
+++ b/lib/gettext/text_domain_manager.rb
@@ -77,11 +77,12 @@ module GetText
     end
 
     def each_text_domains(klass) #:nodoc:
-      lang = Locale.candidates[0]
-      ClassInfo.related_classes(klass, @@gettext_classes).each do |target|
-        if group = @@text_domain_group_pool[target]
-          group.text_domains.each do |text_domain|
-            yield text_domain, lang
+      Locale.candidates.each do |lang|
+        ClassInfo.related_classes(klass, @@gettext_classes).each do |target|
+          if group = @@text_domain_group_pool[target]
+            group.text_domains.each do |text_domain|
+              yield text_domain, lang
+            end
           end
         end
       end

--- a/test/fixtures/simple.rb
+++ b/test/fixtures/simple.rb
@@ -13,4 +13,8 @@ class Simple
   def test_formatted_string
     _("one is %d.") % 1
   end
+
+  def test_plural
+    n_("There is an apple.", "There are %{num} apples.", 5) % {:num => 5}
+  end
 end

--- a/test/po/fr_BE/test1.po
+++ b/test/po/fr_BE/test1.po
@@ -17,14 +17,8 @@ msgstr ""
 
 #: simple.rb:10
 msgid "language"
-msgstr "french"
+msgstr "french-Belgium"
 
 #: simple.rb:14
 msgid "one is %d."
-msgstr "FRENCH:ONE IS %d."
-
-#: simple.rb:18
-msgid "There is an apple."
-msgid_plural "There are %{num} apples."
-msgstr[0] "FRENCH:Il y a une pomme."
-msgstr[1] "FRENCH:Il y a %{num} pommes."
+msgstr "FRENCH-BELGIUM:ONE IS %d."

--- a/test/po/fr_BE_Foo/test1.po
+++ b/test/po/fr_BE_Foo/test1.po
@@ -17,14 +17,4 @@ msgstr ""
 
 #: simple.rb:10
 msgid "language"
-msgstr "french"
-
-#: simple.rb:14
-msgid "one is %d."
-msgstr "FRENCH:ONE IS %d."
-
-#: simple.rb:18
-msgid "There is an apple."
-msgid_plural "There are %{num} apples."
-msgstr[0] "FRENCH:Il y a une pomme."
-msgstr[1] "FRENCH:Il y a %{num} pommes."
+msgstr "french-Belgium-Foo"

--- a/test/test_gettext.rb
+++ b/test/test_gettext.rb
@@ -59,6 +59,29 @@ class TestGetText < Test::Unit::TestCase
     assert_equal("nomsgstr", _("nomsgstr"))
   end
 
+  def test_fallbacks
+    bindtextdomain("test1", "locale")
+    test = Simple.new
+
+    # Translation present in all candidates
+    GetText.set_current_locale("fr_BE_Foo")
+    assert_equal("french-Belgium-Foo", test.test)
+    GetText.set_current_locale("fr_BE")
+    assert_equal("french-Belgium", test.test)
+    GetText.set_current_locale("fr")
+    assert_equal("french", test.test)
+
+    # Translation Missing in fr_BE_Foo (fallback to fr_BE)
+    GetText.set_current_locale("fr_BE_Foo")
+    assert_equal("FRENCH-BELGIUM:ONE IS 1.", test.test_formatted_string)
+
+    # Translation Missing in fr_BE_Foo *and* fr_BE (both languages fallback to fr)
+    GetText.set_current_locale("fr_BE_Foo")
+    assert_equal("FRENCH:Il y a 5 pommes.", test.test_plural)
+    GetText.set_current_locale("fr_BE")
+    assert_equal("FRENCH:Il y a 5 pommes.", test.test_plural)
+  end
+
   def test_empty
     bindtextdomain("test1", "locale")
     assert_equal("japanese", gettext("language"))

--- a/test/test_locale_path.rb
+++ b/test/test_locale_path.rb
@@ -53,9 +53,11 @@ class TestLocalePath < Test::Unit::TestCase
     testdir = File.dirname(File.expand_path(__FILE__))
     path = GetText::LocalePath.new("test1", "#{testdir}/locale")
     assert_equal({
-                   "ja"      => "#{testdir}/locale/ja/LC_MESSAGES/test1.mo",
-                   "fr"      => "#{testdir}/locale/fr/LC_MESSAGES/test1.mo",
-                   "zh_Hant" => "#{testdir}/locale/zh_Hant/LC_MESSAGES/test1.mo"
+                   "ja"        => "#{testdir}/locale/ja/LC_MESSAGES/test1.mo",
+                   "fr"        => "#{testdir}/locale/fr/LC_MESSAGES/test1.mo",
+                   "fr_BE"     => "#{testdir}/locale/fr_BE/LC_MESSAGES/test1.mo",
+                   "fr_BE_Foo" => "#{testdir}/locale/fr_BE_Foo/LC_MESSAGES/test1.mo",
+                   "zh_Hant"   => "#{testdir}/locale/zh_Hant/LC_MESSAGES/test1.mo"
                  },
                  path.locale_paths)
     assert_equal("#{testdir}/locale/ja/LC_MESSAGES/test1.mo",
@@ -66,6 +68,12 @@ class TestLocalePath < Test::Unit::TestCase
                  path.current_path(Locale::Tag.parse("ja_JP.UTF-8")))
     assert_equal(nil,
                  path.current_path(Locale::Tag.parse("en")))
+    assert_equal("#{testdir}/locale/fr/LC_MESSAGES/test1.mo",
+                 path.current_path(Locale::Tag.parse("fr")))
+    assert_equal("#{testdir}/locale/fr_BE/LC_MESSAGES/test1.mo",
+                 path.current_path(Locale::Tag.parse("fr-BE")))
+    assert_equal("#{testdir}/locale/fr_BE_Foo/LC_MESSAGES/test1.mo",
+                 path.current_path(Locale::Tag.parse("fr-BE-Foo")))
     assert_equal("#{testdir}/locale/zh_Hant/LC_MESSAGES/test1.mo",
                  path.current_path(Locale::Tag.parse("zh-Hant")))
   end
@@ -73,7 +81,7 @@ class TestLocalePath < Test::Unit::TestCase
   def test_supported_locales
     testdir = File.dirname(File.expand_path(__FILE__))
     path = GetText::LocalePath.new("test1", "#{testdir}/locale")
-    assert_equal ["fr", "ja", "zh_Hant"], path.supported_locales
+    assert_equal ["fr", "fr_BE", "fr_BE_Foo", "ja", "zh_Hant"], path.supported_locales
 
     path = GetText::LocalePath.new("plural", "#{testdir}/locale")
     assert_equal ["cr", "da", "fr", "ir", "ja", "la", "li", "po", "sl"], path.supported_locales


### PR DESCRIPTION
This feature was discussed on #89

The implementation suggestion of @kou was spot-on, I just added some tests to make sure it works.