### PR TITLE
ci: add Ruby 2.5, 2.6 and 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
+          - "2.5"
+          - "2.6"
+          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"


### PR DESCRIPTION
The gemspec says Ruby >= 2.5.0 is supported, so let's make CI test that.