### PR TITLE
Fix po entry flag text representation

### DIFF
--- a/lib/gettext/po_entry.rb
+++ b/lib/gettext/po_entry.rb
@@ -429,10 +429,10 @@ module GetText
 
       def format_flag_comment
         if @entry.flags.empty?
-          return String.new
+          String.new
         else
           joined_flags = @entry.flags.join(', ')
-          return format_comment(FLAG_MARK, joined_flags)
+          format_comment(FLAG_MARK, joined_flags)
         end
       end
 

--- a/lib/gettext/po_entry.rb
+++ b/lib/gettext/po_entry.rb
@@ -431,7 +431,7 @@ module GetText
         if @entry.flags.empty?
           String.new
         else
-          joined_flags = @entry.flags.join(', ')
+          joined_flags = @entry.flags.join(", ")
           format_comment(FLAG_MARK, joined_flags)
         end
       end

--- a/lib/gettext/po_entry.rb
+++ b/lib/gettext/po_entry.rb
@@ -428,11 +428,12 @@ module GetText
       end
 
       def format_flag_comment
-        formatted_flags = String.new
-        @entry.flags.each do |flag|
-          formatted_flags << format_comment(FLAG_MARK, flag)
+        if @entry.flags.empty?
+          return String.new
+        else
+          joined_flags = @entry.flags.join(', ')
+          return format_comment(FLAG_MARK, joined_flags)
         end
-        formatted_flags
       end
 
       def format_previous_comment

--- a/test/test_po_entry.rb
+++ b/test/test_po_entry.rb
@@ -344,6 +344,20 @@ EOP
       assert_equal(expected_po, entry.to_s)
     end
 
+        def test_multiple_flags
+          entry = GetText::POEntry.new(:normal)
+          entry.msgid = "msgid"
+          entry.msgstr = "msgstr"
+          entry.flags = ["It's the flag.", "fuzzy"]
+
+          expected_po = <<-EOP
+#, It's the flag., fuzzy
+msgid "msgid"
+msgstr "msgstr"
+EOP
+          assert_equal(expected_po, entry.to_s)
+        end
+
     def test_previous
       entry = GetText::POEntry.new(:normal)
       entry.msgid = "msgid"

--- a/test/test_po_entry.rb
+++ b/test/test_po_entry.rb
@@ -344,19 +344,19 @@ EOP
       assert_equal(expected_po, entry.to_s)
     end
 
-        def test_multiple_flags
-          entry = GetText::POEntry.new(:normal)
-          entry.msgid = "msgid"
-          entry.msgstr = "msgstr"
-          entry.flags = ["It's the flag.", "fuzzy"]
+    def test_multiple_flags
+      entry = GetText::POEntry.new(:normal)
+      entry.msgid = "msgid"
+      entry.msgstr = "msgstr"
+      entry.flags = ["It's the flag.", "fuzzy"]
 
-          expected_po = <<-EOP
+      expected_po = <<-EOP
 #, It's the flag., fuzzy
 msgid "msgid"
 msgstr "msgstr"
 EOP
-          assert_equal(expected_po, entry.to_s)
-        end
+      assert_equal(expected_po, entry.to_s)
+    end
 
     def test_previous
       entry = GetText::POEntry.new(:normal)


### PR DESCRIPTION
Format multiple flags into a commma separated single line.
Without this change, at least `msgcat` command, which is one of gettexts commands only loads last flag and the rest are ignored.