### PR TITLE
Update sample/test rhtml files to comply with Herb

### DIFF
--- a/samples/cgi/helloerb.rhtml
+++ b/samples/cgi/helloerb.rhtml
@@ -18,7 +18,7 @@
 <p><%= _("QUERY_STRING") %>: <%= cgi.query_string %></p>
 </div>
 <p><%= _("Call a library method which has another textdomain.") %></p>
-<div class="locale"><%=  lib.hello %></div>
+<div class="locale"><%= lib.hello %></div>
 <p><a href="/"><%= _("Back") %></a></p>
 
 <div class="copyright">

--- a/test/fixtures/erb/case.rhtml
+++ b/test/fixtures/erb/case.rhtml
@@ -9,7 +9,8 @@
 </head>
 <body>
   <%= _('Hello') %>
-  <% case 1 %>
+  <% case %>
+  <% when true %>
   <% end %>
   <%= _('World') %>
 </body>

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -223,7 +223,7 @@ class TestGetTextParser < Test::Unit::TestCase
 
       if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
         assert_target("Hello", ["#{path}:11"])
-        assert_target("World", ["#{path}:14"])
+        assert_target("World", ["#{path}:15"])
       else
         assert_target("Hello", ["#{path}:11"])
         assert_nil(@ary.detect {|elem| elem.msgid == 'World'}) # Not detected. see PR #91
@@ -275,7 +275,7 @@ class TestGetTextParser < Test::Unit::TestCase
       @ary = GetText::ErubiParser.parse(path)
 
       assert_target("Hello", ["#{path}:11"])
-      assert_target("World", ["#{path}:14"]) # Detected with Erubi
+      assert_target("World", ["#{path}:15"]) # Detected with Erubi
     end
   end
 


### PR DESCRIPTION
* Multiple spaces between the start `<%=` and expression is pointed out by Herb linter
* `case` doesn't have `when` is a syntax error